### PR TITLE
automatically resize title for mobile

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "liveServer.settings.port": 5501
-}

--- a/index.html
+++ b/index.html
@@ -23,12 +23,13 @@
         font-weight: bold;
         color: rgb(100, 116, 139);
         text-align: center;
+        margin-top: 7px;
       }
 
       @media (max-width: 500px) {
         #title {
           font-size: 1.3rem; /* Size for screens smaller than 400px */
-          margin-top: 13px;
+          margin-top: 18px;
         }
       }
     </style>

--- a/index.html
+++ b/index.html
@@ -17,16 +17,32 @@
       html, body {
         font-family: 'Calibri', sans-serif;
       }
+      
+      #title {
+        font-size: 1.875rem; /* Default size for larger screens */
+        font-weight: bold;
+        color: rgb(100, 116, 139);
+        text-align: center;
+      }
+
+      @media (max-width: 500px) {
+        #title {
+          font-size: 1.3rem; /* Size for screens smaller than 400px */
+          margin-top: 13px;
+        }
+      }
     </style>
   </head>
   <body>
     <div class="justify-start absolute">
-      <button id="darkMode" class="m-1 left-0 top-0 border-2 shadow-lg bg-white rounded text-3xl p-0.5" onclick="darkMode()">
-        <i class="fa-solid fa-moon"></i>
-      </button>
+      <div class="absolute left-0 top-0 m-2">
+        <button id="darkMode" class="m-1 left-0 top-0 border-2 shadow-lg bg-white rounded text-3xl p-0.5" onclick="darkMode()">
+          <i class="fa-solid fa-moon"></i>
+        </button>
+      </div>
     </div>
     <div class="flex flex-col items-center justify-center">
-      <h1 class="text text-3xl font-bold text-slate-500">
+      <h1 id="title">
         Color Grayscale converter
       </h1>
       <div class="my-5 h-fit rounded-md p-6 shadow-lg bg-white toBlack containers">


### PR DESCRIPTION
Heya! This PR improves mobile responsiveness for the title, reducing its size on screens 500px and smaller, and prevents the dark-mode button from overlapping with the title. Additionally, minor UI adjustments were made to improve spacing.

![ezgif-6-72349dc84b](https://github.com/user-attachments/assets/3defdca4-c874-466e-b67e-a542f2f4c1ea)
